### PR TITLE
feat: Add provision to use cross-account route53 for acm dns validation

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Render and Push terraform docs for main module
         uses: terraform-docs/gh-actions@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
+        exclude: '^[^/]+\.tf$|^modules/acm/.*'
       - id: terraform_tflint
         args:
           - '--args=--only=terraform_deprecated_interpolation'

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Terraform module to deploy production-ready applications and services on an exis
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
@@ -51,6 +51,8 @@ Terraform module to deploy production-ready applications and services on an exis
 | <a name="input_create_s3_bucket_for_alb_logging"></a> [create\_s3\_bucket\_for\_alb\_logging](#input\_create\_s3\_bucket\_for\_alb\_logging) | (Optional) Creates S3 bucket for storing ALB Access and Connection Logs. | `bool` | `true` | no |
 | <a name="input_default_capacity_providers_strategies"></a> [default\_capacity\_providers\_strategies](#input\_default\_capacity\_providers\_strategies) | (Optional) Set of capacity provider strategies to use by default for the cluster. | `any` | `[]` | no |
 | <a name="input_load_balancer"></a> [load\_balancer](#input\_load\_balancer) | Configuration for the Application Load Balancer. | <pre>object({<br/>    name                       = optional(string)<br/>    internal                   = optional(bool, false)<br/>    subnets_ids                = optional(list(string), [])<br/>    security_groups_ids        = optional(list(string), [])<br/>    preserve_host_header       = optional(bool)<br/>    enable_deletion_protection = optional(bool, false)<br/>    access_logs                = optional(any, null)<br/>    connection_logs            = optional(any, null)<br/>    target_groups              = optional(any, {})<br/>    listeners                  = optional(any, {})<br/>    listener_rules             = optional(any, {})<br/>    tags                       = optional(map(string), {})<br/>  })</pre> | `{}` | no |
+| <a name="input_region"></a> [region](#input\_region) | (Optional) AWS region to create resources in. | `string` | `null` | no |
+| <a name="input_route53_assume_role_arn"></a> [route53\_assume\_role\_arn](#input\_route53\_assume\_role\_arn) | (Optional) ARN of the role to assume for Route53 operations. | `string` | `null` | no |
 | <a name="input_s3_bucket_force_destroy"></a> [s3\_bucket\_force\_destroy](#input\_s3\_bucket\_force\_destroy) | (Optional, Default:false) Boolean that indicates all objects (including any locked objects) should be deleted from the bucket when the bucket is destroyed so that the bucket can be destroyed without error. | `bool` | `false` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | (Optional, Forces new resource) Name of the bucket. | `string` | `null` | no |
 | <a name="input_s3_bucket_policy_id_prefix"></a> [s3\_bucket\_policy\_id\_prefix](#input\_s3\_bucket\_policy\_id\_prefix) | (Optional) - Prefix of the ID for the policy document. | `string` | `"ecs-deployment-alb-"` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -93,6 +93,9 @@ module "ecs_deployment" {
       record_zone_id    = data.aws_route53_zone.base_domain.zone_id
     }
   }
+  region = var.region
+  # Cross-account role that ACM module will use for Route53 DNS record creation
+  route53_assume_role_arn = var.route53_assume_role_arn
 
   # Application Load Balancer
   load_balancer = {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -132,3 +132,13 @@ variable "domain_name" {
   description = "Domain name for ACM"
   type        = string
 }
+
+variable "region" {
+  description = "AWS region to deploy resources"
+  type        = string
+}
+
+variable "route53_assume_role_arn" {
+  description = "ARN of the cross-account role for Route53 DNS record creation"
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -243,12 +243,33 @@ resource "aws_ecs_task_definition" "this" {
 ################################################################################
 # Amazon Certificates Manager Sub-module
 ################################################################################
+provider "aws" {
+  region = var.region
+}
+
+# Cross-account provider for Route53
+provider "aws" {
+  alias  = "dns"
+  region = var.region
+
+  dynamic "assume_role" {
+    for_each = var.route53_assume_role_arn != null ? [1] : []
+    content {
+      role_arn = var.route53_assume_role_arn
+    }
+  }
+}
 
 module "acm" {
   source = "./modules/acm"
 
-  for_each = var.create_acm ? var.acm_certificates : {}
+  providers = {
+    aws     = aws
+    aws.dns = aws.dns
+  }
+  route53_assume_role_arn = var.route53_assume_role_arn
 
+  for_each = var.create_acm ? var.acm_certificates : {}
   # ACM Certificate
   certificate_domain_name               = each.value.domain_name
   certificate_subject_alternative_names = try(each.value.subject_alternative_names, null)
@@ -259,8 +280,7 @@ module "acm" {
   # Route53 Record
   record_zone_id         = try(each.value.record_zone_id, null)
   record_allow_overwrite = try(each.value.record_allow_overwrite, null)
-
-  tags = try(each.value.tags, {})
+  tags                   = try(each.value.tags, {})
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -249,7 +249,7 @@ provider "aws" {
 
 # Cross-account provider for Route53
 provider "aws" {
-  alias  = "dns"
+  alias  = "cross_account_provider"
   region = var.region
 
   dynamic "assume_role" {
@@ -264,8 +264,8 @@ module "acm" {
   source = "./modules/acm"
 
   providers = {
-    aws     = aws
-    aws.dns = aws.dns
+    aws                        = aws
+    aws.cross_account_provider = aws.cross_account_provider
   }
   route53_assume_role_arn = var.route53_assume_role_arn
 

--- a/modules/acm/README.md
+++ b/modules/acm/README.md
@@ -31,7 +31,7 @@ This sub-module creates the Amazon-issued certificate for a given domain with `v
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
+| <a name="provider_aws.cross_account_provider"></a> [aws.cross\_account\_provider](#provider\_aws.cross\_account\_provider) | ~> 6.0 |
 
 ## Modules
 
@@ -44,7 +44,7 @@ No modules.
 | [aws_acm_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
 | [aws_acm_certificate_validation.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
 | [aws_route53_record.cross_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.same_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 
 ## Inputs
 

--- a/modules/acm/README.md
+++ b/modules/acm/README.md
@@ -24,12 +24,14 @@ This sub-module creates the Amazon-issued certificate for a given domain with `v
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
 
 ## Modules
 
@@ -41,7 +43,8 @@ No modules.
 |------|------|
 | [aws_acm_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
 | [aws_acm_certificate_validation.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
-| [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.cross_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.same_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 
 ## Inputs
 
@@ -54,6 +57,7 @@ No modules.
 | <a name="input_certificate_validation_option"></a> [certificate\_validation\_option](#input\_certificate\_validation\_option) | (Optional) Configuration block used to specify information about the initial validation of each domain name. | <pre>object({<br/>    domain_name       = string<br/>    validation_domain = string<br/>  })</pre> | `null` | no |
 | <a name="input_record_allow_overwrite"></a> [record\_allow\_overwrite](#input\_record\_allow\_overwrite) | (Optional) Allow creation of this record in Terraform to overwrite an existing record, if any. | `bool` | `true` | no |
 | <a name="input_record_zone_id"></a> [record\_zone\_id](#input\_record\_zone\_id) | (Required) Hosted zone ID for a CloudFront distribution, S3 bucket, ELB, or Route 53 hosted zone. | `string` | n/a | yes |
+| <a name="input_route53_assume_role_arn"></a> [route53\_assume\_role\_arn](#input\_route53\_assume\_role\_arn) | (Optional) IAM role ARN to assume for Route53 operations | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Map of tags to assign to the resource. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -63,5 +67,5 @@ No modules.
 | <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | ARN of the ACM certificate. |
 | <a name="output_acm_certificate_id"></a> [acm\_certificate\_id](#output\_acm\_certificate\_id) | ARN of the ACM certificate. |
 | <a name="output_acm_certificate_validation_id"></a> [acm\_certificate\_validation\_id](#output\_acm\_certificate\_validation\_id) | Identifier of the ACM certificate validation resource. |
-| <a name="output_route53_record_id"></a> [route53\_record\_id](#output\_route53\_record\_id) | Identifier of the Route53 Record for validation of the ACM certificate. |
+| <a name="output_route53_record_id"></a> [route53\_record\_id](#output\_route53\_record\_id) | Identifier of the Route53 Record (supports same & cross-account). |
 <!-- END_TF_DOCS -->

--- a/modules/acm/main.tf
+++ b/modules/acm/main.tf
@@ -14,7 +14,7 @@ terraform {
       version = "~> 6.0"
       configuration_aliases = [
         aws,
-        aws.dns
+        aws.cross_account_provider
       ]
     }
   }
@@ -50,7 +50,7 @@ resource "aws_acm_certificate" "this" {
 # ACM Validation
 ################################################################################
 
-resource "aws_route53_record" "same_account" {
+resource "aws_route53_record" "this" {
   count = var.route53_assume_role_arn == null ? 1 : 0
 
   zone_id         = var.record_zone_id
@@ -63,7 +63,7 @@ resource "aws_route53_record" "same_account" {
 
 resource "aws_route53_record" "cross_account" {
   count    = var.route53_assume_role_arn != null ? 1 : 0
-  provider = aws.dns
+  provider = aws.cross_account_provider
 
 
   zone_id         = var.record_zone_id
@@ -79,7 +79,7 @@ resource "aws_acm_certificate_validation" "this" {
 
   validation_record_fqdns = [
     var.route53_assume_role_arn == null ?
-    aws_route53_record.same_account[0].fqdn :
+    aws_route53_record.this[0].fqdn :
     aws_route53_record.cross_account[0].fqdn
   ]
 }

--- a/modules/acm/main.tf
+++ b/modules/acm/main.tf
@@ -7,19 +7,6 @@ locals {
   }
 }
 
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0"
-      configuration_aliases = [
-        aws,
-        aws.cross_account_provider
-      ]
-    }
-  }
-}
-
 ################################################################################
 # ACM Certificate
 ################################################################################

--- a/modules/acm/outputs.tf
+++ b/modules/acm/outputs.tf
@@ -17,9 +17,14 @@ output "acm_certificate_arn" {
 ################################################################################
 
 output "route53_record_id" {
-  description = "Identifier of the Route53 Record for validation of the ACM certificate."
-  value       = aws_route53_record.this.id
+  description = "Identifier of the Route53 Record (supports same & cross-account)."
+  value = (
+    var.route53_assume_role_arn == null
+    ? aws_route53_record.same_account[0].id
+    : aws_route53_record.cross_account[0].id
+  )
 }
+
 
 ################################################################################
 # ACM Certificate Validation

--- a/modules/acm/outputs.tf
+++ b/modules/acm/outputs.tf
@@ -20,7 +20,7 @@ output "route53_record_id" {
   description = "Identifier of the Route53 Record (supports same & cross-account)."
   value = (
     var.route53_assume_role_arn == null
-    ? aws_route53_record.same_account[0].id
+    ? aws_route53_record.this[0].id
     : aws_route53_record.cross_account[0].id
   )
 }

--- a/modules/acm/providers.tf
+++ b/modules/acm/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+      configuration_aliases = [
+        aws,
+        aws.cross_account_provider
+      ]
+    }
+  }
+}

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -60,3 +60,9 @@ variable "record_allow_overwrite" {
   nullable    = false
   default     = true
 }
+
+variable "route53_assume_role_arn" {
+  type        = string
+  default     = null
+  description = "(Optional) IAM role ARN to assume for Route53 operations"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -199,3 +199,15 @@ variable "acm_certificates" {
   nullable = false
   default  = {}
 }
+
+variable "region" {
+  description = "(Optional) AWS region to create resources in."
+  type        = string
+  default     = null
+}
+
+variable "route53_assume_role_arn" {
+  description = "(Optional) ARN of the role to assume for Route53 operations."
+  type        = string
+  default     = null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
**Terraform plan for same account:**
`Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.acm["base_domain"].aws_acm_certificate.this will be created
  + resource "aws_acm_certificate" "this" {
      + arn                       = (known after apply)
      + domain_name               = "kong.staging.gaussb.io"
      + domain_validation_options = [
          + {
              + domain_name           = "kong.staging.gaussb.io"
              + resource_record_name  = (known after apply)
              + resource_record_type  = (known after apply)
              + resource_record_value = (known after apply)
            },
        ]
      + id                        = (known after apply)
      + key_algorithm             = "RSA_2048"
      + not_after                 = (known after apply)
      + not_before                = (known after apply)
      + pending_renewal           = (known after apply)
      + region                    = "ap-south-1"
      + renewal_eligibility       = (known after apply)
      + renewal_summary           = (known after apply)
      + status                    = (known after apply)
      + subject_alternative_names = [
          + "kong.staging.gaussb.io",
        ]
      + tags                      = {
          + "env" = "dev"
        }
      + tags_all                  = {
          + "env" = "dev"
        }
      + type                      = (known after apply)
      + validation_emails         = (known after apply)
      + validation_method         = "DNS"

      + options (known after apply)
    }

  # module.acm["base_domain"].aws_acm_certificate_validation.this will be created
  + resource "aws_acm_certificate_validation" "this" {
      + certificate_arn         = (known after apply)
      + id                      = (known after apply)
      + region                  = "ap-south-1"
      + validation_record_fqdns = (known after apply)
    }

  # module.acm["base_domain"].aws_route53_record.same_account[0] will be created
  + resource "aws_route53_record" "same_account" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z0105802SJKE46BQ70GU"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.`


**Terraform plan for cross account:**
`
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.acm["base_domain"].aws_acm_certificate.this will be created
  + resource "aws_acm_certificate" "this" {
      + arn                       = (known after apply)
      + domain_name               = "kong.staging.gaussb.io"
      + domain_validation_options = [
          + {
              + domain_name           = "kong.staging.gaussb.io"
              + resource_record_name  = (known after apply)
              + resource_record_type  = (known after apply)
              + resource_record_value = (known after apply)
            },
        ]
      + id                        = (known after apply)
      + key_algorithm             = "RSA_2048"
      + not_after                 = (known after apply)
      + not_before                = (known after apply)
      + pending_renewal           = (known after apply)
      + region                    = "ap-south-1"
      + renewal_eligibility       = (known after apply)
      + renewal_summary           = (known after apply)
      + status                    = (known after apply)
      + subject_alternative_names = [
          + "kong.staging.gaussb.io",
        ]
      + tags                      = {
          + "env" = "dev"
        }
      + tags_all                  = {
          + "env" = "dev"
        }
      + type                      = (known after apply)
      + validation_emails         = (known after apply)
      + validation_method         = "DNS"

      + options (known after apply)
    }

  # module.acm["base_domain"].aws_acm_certificate_validation.this will be created
  + resource "aws_acm_certificate_validation" "this" {
      + certificate_arn         = (known after apply)
      + id                      = (known after apply)
      + region                  = "ap-south-1"
      + validation_record_fqdns = (known after apply)
    }

  # module.acm["base_domain"].aws_route53_record.cross_account[0] will be created
  + resource "aws_route53_record" "cross_account" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z0105802SJKE46BQ70GU"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now
`


**This is the terraform plan when the resource is already created with older version and when user wants to change to newer version:**
`terraform plan
module.ecs-deployment_acm["base_domain"].aws_acm_certificate.this: Refreshing state... [id=arn:aws:acm:ap-south-1:471112575944:certificate/51b7aab4-9b03-479a-a4c3-9d3aae34348e]
module.ecs-deployment_acm["base_domain"].aws_route53_record.this[0]: Refreshing state... [id=Z0105802SJKE46BQ70GU__73523f433659a8ecb8b3cbb19ed15127.kong.staging.gaussb.io._CNAME]
module.ecs-deployment_acm["base_domain"].aws_acm_certificate_validation.this: Refreshing state... [id=2025-11-21 05:24:03.256 +0000 UTC]

Terraform will perform the following actions:

  # module.ecs-deployment_acm["base_domain"].aws_route53_record.this has moved to module.ecs-deployment_acm["base_domain"].aws_route53_record.this[0]
    resource "aws_route53_record" "this" {
        id                               = "Z0105802SJKE46BQ70GU__73523f433659a8ecb8b3cbb19ed15127.kong.staging.gaussb.io._CNAME"
        name                             = "_73523f433659a8ecb8b3cbb19ed15127.kong.staging.gaussb.io"
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.`